### PR TITLE
Avoid assigning reviewers for the bitnami-bot PRs

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -39,6 +39,7 @@ jobs:
           # creating env variable "on the fly"
           echo "TRIAGE_TEAM_STRING=$TRIAGE_TEAM_STRING" >> $GITHUB_ENV
       - name: Assign to a person to work on it
+        if: ${{ github.actor != 'bitnami-bot' }}
         uses: pozil/auto-assign-issue@v1.7.3
         with:
           numOfAssignee: 1
@@ -47,7 +48,7 @@ jobs:
           # teams: XXX
           repo-token: "${{ secrets.GHPROJECT_TOKEN }}"
       - name: Send to the board
-        if: ${{ github.actor != 'bitnami-bot'  }}
+        if: ${{ github.actor != 'bitnami-bot' }}
         uses: peter-evans/create-or-update-project-card@v2
         with:
           project-name: Support


### PR DESCRIPTION
### Description of the change

Avoid assigning reviewers for the bitnami-bot PRs. Replicate changes from https://github.com/bitnami/containers/pull/263

### Benefits

Automated PRs will not have reviewers by default.

### Possible drawbacks

If _bitnami-bot_ opens a non-automated PR, will not have a reviewer assigned.