### PR TITLE
[bitnami/*] Parametrising support flow by getting GH members from GH teams

### DIFF
--- a/.github/workflows/.env
+++ b/.github/workflows/.env
@@ -1,9 +1,9 @@
 BITNAMI_TEAM='["bitnami-bot","jotamartos","alemorcuq","agomezmoron","carrodher","corico44","dgomezleon","fmulero","FraPazGal","javsalgar","gongomgra","joancafom","marcosbc","aoterolorenzo","CeliaGMqrz","Mauraza","mdhont","migruiz4","rafariossaa"]'
-SUPPORT_TEAM='["jotamartos","gongomgra","joancafom","mdhont"]'
-TRIAGE_TEAM='["jotamartos","gongomgra"]'
 IN_PROGRESS_COLUMN_ID=18834407
 TRIAGE_COLUMN_ID=18834406
 SOLVED_COLUMN_ID=18834409
 ON_HOLD_COLUMN_ID=18834408
 BITNAMI_COLUMN_ID=18976470
 PENDING_COLUMN_ID=18872833
+SUPPORT_TEAM_NAME='vms-support'
+TRIAGE_TEAM_NAME='vms-triage'

--- a/.github/workflows/move-closed-issues.yml
+++ b/.github/workflows/move-closed-issues.yml
@@ -29,25 +29,18 @@ jobs:
         uses: xom9ikk/dotenv@v1.0.2
         with:
           path: .github/workflows/
-      - name: Preparing string variables
-        run: |
-          TRIAGE_TEAM_STRING=${TRIAGE_TEAM/[/}
-          TRIAGE_TEAM_STRING=${TRIAGE_TEAM_STRING/]/}
-          TRIAGE_TEAM_STRING=${TRIAGE_TEAM_STRING//'"'/}
-          # creating env variable "on the fly"
-          echo "TRIAGE_TEAM_STRING=$TRIAGE_TEAM_STRING" >> $GITHUB_ENV
       - name: Send to the Solved column
         uses: peter-evans/create-or-update-project-card@v2
         with:
           project-name: Support
           # If the author comes from Bitnami, send it to Bitnami. Otherwise, all to Triage
           column-name: 'Solved'
-          token: "${{ secrets.GHPROJECT_TOKEN }}"
+          token: "${{ secrets.BITNAMI_BOT_TOKEN }}"
           issue-number: ${{ github.event_name != 'issues' && github.event.number || github.event.issue.number }}
       - name: Solved labeling
         # Only if moved into Solved
         uses: andymckay/labeler@1.0.4
         with:
-          repo-token: "${{ secrets.GHPROJECT_TOKEN }}"
+          repo-token: "${{ secrets.BITNAMI_BOT_TOKEN }}"
           add-labels: "solved"
           remove-labels: "in-progress, on-hold, triage"

--- a/.github/workflows/moving-cards.yml
+++ b/.github/workflows/moving-cards.yml
@@ -33,7 +33,7 @@ jobs:
         if: ${{ github.event.project_card.column_id == env.ON_HOLD_COLUMN_ID  }}
         uses: andymckay/labeler@1.0.4
         with:
-          repo-token: "${{ secrets.GHPROJECT_TOKEN }}"
+          repo-token: "${{ secrets.BITNAMI_BOT_TOKEN }}"
           add-labels: "on-hold"
           remove-labels: "triage"
       - name: In progress labeling
@@ -41,7 +41,7 @@ jobs:
         if: ${{ github.event.project_card.column_id == env.IN_PROGRESS_COLUMN_ID  }}
         uses: andymckay/labeler@1.0.4
         with:
-          repo-token: "${{ secrets.GHPROJECT_TOKEN }}"
+          repo-token: "${{ secrets.BITNAMI_BOT_TOKEN }}"
           add-labels: "in-progress"
           remove-labels: "on-hold, triage"
       - name: Solved labeling
@@ -49,7 +49,7 @@ jobs:
         if: ${{ github.event.project_card.column_id == env.SOLVED_COLUMN_ID  }}
         uses: andymckay/labeler@1.0.4
         with:
-          repo-token: "${{ secrets.GHPROJECT_TOKEN }}"
+          repo-token: "${{ secrets.BITNAMI_BOT_TOKEN }}"
           add-labels: "solved"
           remove-labels: "in-progress, on-hold, triage"
   assign-assignee-if-needed:
@@ -64,20 +64,12 @@ jobs:
         uses: xom9ikk/dotenv@v1.0.2
         with:
           path: .github/workflows/
-      - name: Preparing string variables
-        run: |
-          SUPPORT_TEAM_STRING=${SUPPORT_TEAM/[/}
-          SUPPORT_TEAM_STRING=${SUPPORT_TEAM_STRING/]/}
-          SUPPORT_TEAM_STRING=${SUPPORT_TEAM_STRING//'"'/}
-          # creating env variable "on the fly"
-          echo "SUPPORT_TEAM_STRING=$SUPPORT_TEAM_STRING" >> $GITHUB_ENV
       - name: Assign to a person to work on it
         # Only if moved into In progress FROM Triage
         if: ${{ github.event.project_card.column_id == env.IN_PROGRESS_COLUMN_ID && github.event.changes != null && github.event.changes.column_id && github.event.changes.column_id.from == env.TRIAGE_COLUMN_ID }}
         uses: pozil/auto-assign-issue@v1.7.3
         with:
           numOfAssignee: 1
-          assignees: ${{ env.SUPPORT_TEAM_STRING }}
           removePreviousAssignees: true
-          # teams: XXX
-          repo-token: "${{ secrets.GHPROJECT_TOKEN }}"
+          teams: ${{ env.SUPPORT_TEAM_NAME }}
+          repo-token: "${{ secrets.BITNAMI_BOT_TOKEN }}"

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -2,7 +2,7 @@ name: '[Support] Synchronize labels from the charts repository'
 on:
   schedule:
     # Daily
-    - cron: '0 1 * * *'
+    - cron: '0 3 * * *'
 permissions:
   issues: write
 

--- a/.github/workflows/sync-teams.yml
+++ b/.github/workflows/sync-teams.yml
@@ -2,7 +2,7 @@ name: '[Support] Synchronize team members in the .env file'
 on:
   schedule:
     # Daily
-    - cron: '0 1 * * *'
+    - cron: '0 5 * * *'
 permissions:
   repository-projects: write
 

--- a/.github/workflows/sync-teams.yml
+++ b/.github/workflows/sync-teams.yml
@@ -1,0 +1,39 @@
+name: '[Support] Synchronize team members in the .env file'
+on:
+  schedule:
+    # Daily
+    - cron: '0 1 * * *'
+permissions:
+  repository-projects: write
+
+jobs:
+  sync-support-teams:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repo checkout
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.BITNAMI_BOT_TOKEN }}
+          fetch-depth: 1
+      - name: Load .env file
+        uses: xom9ikk/dotenv@v1.0.2
+        with:
+          path: .github/workflows/
+      - name: Updating members of the Bitnami team
+        run: |
+          TEAM_MEMBERS=$(curl --request GET \
+          --url https://api.github.com/orgs/bitnami/teams/developers/members \
+          --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+          --header 'content-type: application/json' \
+          | jq 'sort_by(.login)|map(.login)|join(",")')
+          TEAM_MEMBERS='['${TEAM_MEMBERS//','/'","'}']'
+          if [ $TEAM_MEMBERS != $BITNAMI_TEAM ]; then
+            echo "Replacing $BITNAMI_TEAM for $TEAM_MEMBERS"
+            sed -i "s|BITNAMI_TEAM=.*$|BITNAMI_TEAM='${TEAM_MEMBERS}'|g" .github/workflows/.env
+            git config user.name "bitnami-bot"
+            git config user.email "bitnami-bot@vmware.com"
+            git commit -s -m"[bitnami-bot] Updating Bitnami team members" .github/workflows/.env 
+            git push
+          else
+            echo "BITNAMI_TEAM is updated and nothing should be done"
+          fi

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -32,34 +32,26 @@ jobs:
         uses: xom9ikk/dotenv@v1.0.2
         with:
           path: .github/workflows/
-      - name: Preparing string variables
-        run: |
-          TRIAGE_TEAM_STRING=${TRIAGE_TEAM/[/}
-          TRIAGE_TEAM_STRING=${TRIAGE_TEAM_STRING/]/}
-          TRIAGE_TEAM_STRING=${TRIAGE_TEAM_STRING//'"'/}
-          # creating env variable "on the fly"
-          echo "TRIAGE_TEAM_STRING=$TRIAGE_TEAM_STRING" >> $GITHUB_ENV
       - name: Assign to a person to work on it
         uses: pozil/auto-assign-issue@v1.7.3
         with:
           numOfAssignee: 1
-          assignees: ${{ env.TRIAGE_TEAM_STRING }}
           removePreviousAssignees: false
-          # teams: XXX
-          repo-token: "${{ secrets.GHPROJECT_TOKEN }}"
+          teams: ${{ env.TRIAGE_TEAM_NAME }}
+          repo-token: "${{ secrets.BITNAMI_BOT_TOKEN }}"
       - name: Send to the board
         uses: peter-evans/create-or-update-project-card@v2
         with:
           project-name: Support
           # If the author comes from Bitnami, send it to Bitnami. Otherwise, all to Triage
           column-name: ${{ (contains(fromJson(env.BITNAMI_TEAM), github.actor)) && 'From Bitnami' || 'Triage' }}
-          token: "${{ secrets.GHPROJECT_TOKEN }}"
+          token: "${{ secrets.BITNAMI_BOT_TOKEN }}"
           issue-number: ${{ github.event_name != 'issues' && github.event.number || github.event.issue.number }}
       - name: Triage labeling
         # Only if moved into Solved
         uses: andymckay/labeler@1.0.4
         with:
-          repo-token: "${{ secrets.GHPROJECT_TOKEN }}"
+          repo-token: "${{ secrets.BITNAMI_BOT_TOKEN }}"
           add-labels: ${{ (!contains(fromJson(env.BITNAMI_TEAM), github.actor)) && 'triage' || 'bitnami' }}
           # For reopened issues
           remove-labels: "solved"


### PR DESCRIPTION
Signed-off-by: Alejandro Gómez <morona@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

* Removing _triage_ and _support_ teams as fixed variables in the .env file.
* Adding an action to update the BITNAMI_TEAM variable in the .env file based on GH team.
* Changing the assignations by using GH teams instead of an array of users.
* Changing the GH token into the bitnami-bot one.

### Benefits

Managing the triage, support and bitnami teams by managing them on GH.

### Possible drawbacks

None detected.
