### PR TITLE
Bump actions/checkout version from v2 to v3

### DIFF
--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Repo checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 1
       - name: Load .env file


### PR DESCRIPTION
We are receiving the following warning in relation to some of the GH actions we are running as part of our release and support workflows:

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/checkout

Taking a look at the version used for `actions/checkout`, currently, there is a mix of `v2` and `v3`:
```console
$ ag 'actions/checkout' .github
.github/workflows/sync-teams.yml
14:        uses: actions/checkout@v3

.github/workflows/triage.yml
28:        uses: actions/checkout@v3

.github/workflows/move-closed-issues.yml
25:        uses: actions/checkout@v3

.github/workflows/comments.yml
21:        uses: actions/checkout@v2

.github/workflows/moving-cards.yml
23:        uses: actions/checkout@v3
60:        uses: actions/checkout@v3
```

According to the above warning, we should bump the `actions/checkout` version to `v3` everywhere in order to use the latest NodeJS version. Taking a look at the [_actions/checkout_ releases](https://github.com/actions/checkout/releases/tag/v3.0.0), the new node version is used from 3.0.0 on.