### PR TITLE
Bump actions/stale version to v5

### DIFF
--- a/.github/workflows/clossing-issues.yml
+++ b/.github/workflows/clossing-issues.yml
@@ -12,7 +12,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v4
+      - uses: actions/stale@v5
         with:
           any-of-labels: 'solved'
           stale-issue-label: 'solved'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v3
+      - uses: actions/stale@v5
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           stale-issue-message: 'This Issue has been automatically marked as "stale" because it has not had recent activity (for 15 days). It will be closed if no further activity occurs. Thanks for the feedback.'


### PR DESCRIPTION
We are receiving the following warning in relation to some of the GH actions we are running as part of our release and support workflows:

> **Stale**
> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/stale


Taking a look at the version used for `actions/stale`:
```console
$ ag 'actions/stale' charts/.github vms/.github containers/.github
charts/.github/workflows/stale.yml
15:      - uses: actions/stale@v4
26:      - uses: actions/stale@v4

charts/.github/workflows/clossing-issues.yml
13:      - uses: actions/stale@v4

vms/.github/workflows/stale.yml
10:      - uses: actions/stale@v3

vms/.github/workflows/clossing-issues.yml
15:      - uses: actions/stale@v4

containers/.github/workflows/stale.yml
15:      - uses: actions/stale@v4
26:      - uses: actions/stale@v4

containers/.github/workflows/clossing-issues.yml
13:      - uses: actions/stale@v4
```

According to the above warning, we should bump the `actions/stale` version to, at least, `v5` everywhere in order to use the latest NodeJS version. Taking a look at the [`actions/stale` releases](https://github.com/actions/stale/releases/tag/v5.0.0), the new NodeJS version is used from `v5` on.

(flag) Please note there is a [new major version (`v6`)](https://github.com/actions/stale/releases/tag/v6.0.0) containing some breaking changes. That's why I'm suggesting a bump to `v5`