### PR TITLE
[bitnami/**] Bump and changing origin for labeler action to fmulero/labeler@1.0.5

### DIFF
--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Label as triage back
         # Only if commented when solved
         if: ${{ contains(github.event.issue.labels.*.name, 'solved') }}
-        uses: andymckay/labeler@1.0.4
+        uses: fmulero/labeler@1.0.5
         with:
           add-labels: "triage"
           remove-labels: "solved"

--- a/.github/workflows/move-closed-issues.yml
+++ b/.github/workflows/move-closed-issues.yml
@@ -39,7 +39,7 @@ jobs:
           issue-number: ${{ github.event_name != 'issues' && github.event.number || github.event.issue.number }}
       - name: Solved labeling
         # Only if moved into Solved
-        uses: andymckay/labeler@1.0.4
+        uses: fmulero/labeler@1.0.5
         with:
           repo-token: "${{ secrets.BITNAMI_BOT_TOKEN }}"
           add-labels: "solved"

--- a/.github/workflows/moving-cards.yml
+++ b/.github/workflows/moving-cards.yml
@@ -31,7 +31,7 @@ jobs:
       - name: On hold labeling
         # Only if moved into on hold
         if: ${{ github.event.project_card.column_id == env.ON_HOLD_COLUMN_ID  }}
-        uses: andymckay/labeler@1.0.4
+        uses: fmulero/labeler@1.0.5
         with:
           repo-token: "${{ secrets.BITNAMI_BOT_TOKEN }}"
           add-labels: "on-hold"
@@ -39,7 +39,7 @@ jobs:
       - name: In progress labeling
         # Only if moved into In progress
         if: ${{ github.event.project_card.column_id == env.IN_PROGRESS_COLUMN_ID  }}
-        uses: andymckay/labeler@1.0.4
+        uses: fmulero/labeler@1.0.5
         with:
           repo-token: "${{ secrets.BITNAMI_BOT_TOKEN }}"
           add-labels: "in-progress"
@@ -47,7 +47,7 @@ jobs:
       - name: Solved labeling
         # Only if moved into Solved
         if: ${{ github.event.project_card.column_id == env.SOLVED_COLUMN_ID  }}
-        uses: andymckay/labeler@1.0.4
+        uses: fmulero/labeler@1.0.5
         with:
           repo-token: "${{ secrets.BITNAMI_BOT_TOKEN }}"
           add-labels: "solved"

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -49,7 +49,7 @@ jobs:
           issue-number: ${{ github.event_name != 'issues' && github.event.number || github.event.issue.number }}
       - name: Triage labeling
         # Only if moved into Solved
-        uses: andymckay/labeler@1.0.4
+        uses: fmulero/labeler@1.0.5
         with:
           repo-token: "${{ secrets.BITNAMI_BOT_TOKEN }}"
           add-labels: ${{ (!contains(fromJson(env.BITNAMI_TEAM), github.actor)) && 'triage' || 'bitnami' }}


### PR DESCRIPTION
Signed-off-by: Alejandro Gómez <morona@vmware.com>

We are receiving the following warning in relation to some of the GH actions we are running as part of our release and support workflows:

> **Reviewal for automated PRs**
> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: andymckay/labeler

Taking a look at the repository of `andymckay/labeler` was archived some days ago. @fmulero has been working on some changes using [`fmulero/labeler`](https://github.com/fmulero/labeler) as the origin and the new version which pumps the Node.js engine into 16.