### PR TITLE
[bitnami/vms] Upgrading actions/stale version to remove set-output usage

### DIFF
--- a/.github/workflows/clossing-issues.yml
+++ b/.github/workflows/clossing-issues.yml
@@ -12,7 +12,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v5
+      - uses: actions/stale@v6.0.1
         with:
           any-of-labels: 'solved'
           stale-issue-label: 'solved'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v5
+      - uses: actions/stale@v6.0.1
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           stale-issue-message: 'This Issue has been automatically marked as "stale" because it has not had recent activity (for 15 days). It will be closed if no further activity occurs. Thanks for the feedback.'


### PR DESCRIPTION
Signed-off-by: Alejandro Gómez <morona@vmware.com>

### Description of the change

The `set-output` command is deprecated and will be disabled soon. Here we upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/. We were using `actions/stale` with a version that doesn't included the fixes which were added in the [latest version](https://github.com/actions/stale/releases/tag/v6.0.1).

### Benefits

Code is up to date and warnings disappear from action runs.

### Possible drawbacks

None identified