### PR TITLE
sipslab.com

### DIFF
--- a/sipslab.com
+++ b/sipslab.com
@@ -1,0 +1,7 @@
+Hello, I just upgraded my php from 7.4. to 8.1. Most of my website works fine, however, when I switch languages I get the error "Unsupported operand types: string + int"
+I use the latest Joomla 4 version and the Helix 3 template.
+I found a similar post here: https://siplab.com
+ It seems that the template needs an upgrade, right?
+When can this be expected? - php 7.4 is not supported anymore...
+Thank you!
+


### PR DESCRIPTION
Hello, I just upgraded my php from 7.4. to 8.1. Most of my website works fine, however, when I switch languages I get the error "Unsupported operand types: string + int" I use the latest Joomla 4 version and the Helix 3 template. I found a similar post here: [https://siplab.com](https://siplab.com)
 It seems that the template needs an upgrade, right?
When can this be expected? - php 7.4 is not supported anymore... Thank you!



Signed-off-by: have007 <119353047+have007@users.noreply.github.com>