### PR TITLE
[bitnami/vms] review and improve workflow permissions

### DIFF
--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -4,9 +4,10 @@ on:
     types:
       - created
 permissions:
+  contents: read
   repository-projects: write
-  issues: write
-  pull-requests: write
+  issues: read
+  pull-requests: read
 # Avoid concurrency over the same issue
 concurrency:
   group: card-movement-${{ github.event.issue.number }}

--- a/.github/workflows/moving-cards.yml
+++ b/.github/workflows/moving-cards.yml
@@ -5,12 +5,10 @@ on:
     types:
       - created
       - moved
-
 permissions:
-  repository-projects: read
+  contents: read
   issues: write
   pull-requests: write
-
 jobs:
   get-issue:
     runs-on: ubuntu-latest
@@ -112,9 +110,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - get-issue
-    # The job shouldn't run for solved cards or new PRs created by bitnami-bot
-    if: |
-      (github.event.action != 'created' || needs.get-issue.outputs.type != 'pull_request' || needs.get-issue.outputs.author != 'bitnami-bot')
+    # The job shouldn't run for solved cards
     steps:
       - name: Repo checkout
         uses: actions/checkout@v3
@@ -127,20 +123,22 @@ jobs:
       - name: Assign to a person to work on it
         # Assign when there is nobody assigned or the card is new
         if: ${{ github.event.project_card.column_id != env.SOLVED_COLUMN_ID && (needs.get-issue.outputs.assignees == '[]' || github.event.action == 'created') }}
-        uses: pozil/auto-assign-issue@v1.9.0
+        uses: pozil/auto-assign-issue@v1.11.0
         with:
           numOfAssignee: 1
           teams: ${{ github.event.project_card.column_id == env.BITNAMI_COLUMN_ID && env.SUPPORT_TEAM_NAME || (github.event.project_card.column_id == env.BUILD_MAINTENANCE_COLUMN_ID && env.BUILD_MAINTAINERS_TEAM_NAME || env.TRIAGE_TEAM_NAME) }}
           repo-token: ${{ secrets.BITNAMI_BOT_TOKEN }}
+          allowSelfAssign: false
       - name: Reassign when moved into 'In progress' from 'Triage'
         # Reassigned when moved into In progress FROM Triage
         if: |
           github.event.action == 'moved' && needs.get-issue.outputs.assignees != '[]' &&
           github.event.project_card.column_id == env.IN_PROGRESS_COLUMN_ID &&
           github.event.changes.column_id.from == env.TRIAGE_COLUMN_ID
-        uses: pozil/auto-assign-issue@v1.9.0
+        uses: pozil/auto-assign-issue@v1.11.0
         with:
           numOfAssignee: 1
           removePreviousAssignees: true
           teams: ${{ env.SUPPORT_TEAM_NAME }}
           repo-token: ${{ secrets.BITNAMI_BOT_TOKEN }}
+          allowSelfAssign: false

--- a/.github/workflows/sync-teams.yml
+++ b/.github/workflows/sync-teams.yml
@@ -4,8 +4,8 @@ on:
     # Daily
     - cron: '0 5 * * *'
 permissions:
-  repository-projects: write
-
+  # All write actions are executed with BITNAMI_BOT
+  contents: write
 jobs:
   sync-support-teams:
     runs-on: ubuntu-latest
@@ -32,7 +32,7 @@ jobs:
             sed -i "s|BITNAMI_TEAM=.*$|BITNAMI_TEAM='${TEAM_MEMBERS}'|g" .github/workflows/.env
             git config user.name "bitnami-bot"
             git config user.email "bitnami-bot@vmware.com"
-            git commit -s -m"[bitnami-bot] Updating Bitnami team members" .github/workflows/.env 
+            git commit -s -m"[bitnami-bot] Updating Bitnami team members" .github/workflows/.env
             git push
           else
             echo "BITNAMI_TEAM is updated and nothing should be done"

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -10,6 +10,8 @@ on:
       - reopened
       - opened
 permissions:
+  # Please note that projects cards are created/moved with Bitnami Bot (that's reason to use pull_request_target)
+  contents: read
   issues: write
   pull-requests: write
 # Avoid concurrency over the same issue


### PR DESCRIPTION
### Description of the change

Review and improve workflow permissions

### Benefits

Reduce the privileges of the GitHub token and use `pull_request` instead of `pull_request_target` to reduce secrets exposure. 

### Possible drawbacks

None identified.

### Additional information

https://github.com/bitnami/charts/pull/16908
https://github.com/bitnami/containers/pull/35293
https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
