### PR TITLE
[bitnami/vms] Revisit workflow permissions

### DIFF
--- a/.github/workflows/clossing-issues.yml
+++ b/.github/workflows/clossing-issues.yml
@@ -3,11 +3,8 @@ on:
   schedule:
     # Hourly
     - cron: '0 * * * *'
-
-permissions:
-  issues: write
-  repository-projects: write
-
+# Remove all permissions by default. Actions are performed by Bitnami Bot
+permissions: {}
 jobs:
   stale:
     runs-on: ubuntu-latest
@@ -18,4 +15,4 @@ jobs:
           stale-issue-label: 'solved'
           days-before-stale: 0
           days-before-close: 0
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          repo-token: ${{ secrets.BITNAMI_BOT_TOKEN }}

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -3,17 +3,19 @@ on:
   issue_comment:
     types:
       - created
-permissions:
-  contents: read
-  repository-projects: write
-  issues: read
-  pull-requests: read
+# Remove all permissions by default
+permissions: {}
 # Avoid concurrency over the same issue
 concurrency:
   group: card-movement-${{ github.event.issue.number }}
 jobs:
   comments_handler:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      repository-projects: write
+      issues: read
+      pull-requests: read
     steps:
       - name: Repo checkout
         uses: actions/checkout@v3

--- a/.github/workflows/delete-solved-cards.yml
+++ b/.github/workflows/delete-solved-cards.yml
@@ -4,11 +4,14 @@ on:
   schedule:
     # Every 2 hours
     - cron: '15 0/2 * * *'
-permissions:
-  repository-projects: write
+# Remove all permissions by default
+permissions: {}
 jobs:
   delete-cards:
     runs-on: ubuntu-latest
+    permissions:
+      repository-projects: write
+      contents: read
     steps:
       - name: Repo checkout
         uses: actions/checkout@v3

--- a/.github/workflows/markdown-linter.yml
+++ b/.github/workflows/markdown-linter.yml
@@ -5,23 +5,26 @@ on:
       - main
     paths:
       - '**.md'
-permissions:
-  contents: read
+# Remove all permissions by default
+permissions: {}
 jobs:
   markdown-linter:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Install mardownlint
         run: npm install -g markdownlint-cli@0.33.0
       - name: Checkout project
         uses: actions/checkout@v3
       - name: Execute markdownlint
+        env:
+          DIFF_URL: "${{github.event.pull_request.diff_url}}"
+          TEMP_FILE: "${{runner.temp}}/pr-${{github.event.number}}.diff"
         run: |
-          # Using the Github API to detect the files changed as git merge-base stops working when the branch is behind
-          # and jitterbit/get-changed-files does not support pull_request_target
-          URL="https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files"
-          files_changed_data=$(curl -s --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' -X GET -G "$URL")
-          files_changed="$(echo "$files_changed_data" | jq -r '.[] | .filename')"
+          # This request doesn't consume API calls.
+          curl -Lkso $TEMP_FILE $DIFF_URL
+          files_changed="$(sed -nr 's/[\-\+]{3} [ab]\/(.*)/\1/p' $TEMP_FILE | sort | uniq)"
           md_files="$(echo "$files_changed" | grep -o ".*\.md$" | sort | uniq || true)"
           # Create an empty file, useful when the PR changes ignored files
           touch ${{runner.temp}}/output

--- a/.github/workflows/move-closed-issues.yml
+++ b/.github/workflows/move-closed-issues.yml
@@ -6,8 +6,8 @@ on:
   pull_request_target:
     types:
       - closed
-permissions:
-  repository-projects: write
+# Remove all permissions by default. Actions are performed by Bitnami Bot
+permissions: {}
 # Avoid concurrency over the same issue
 concurrency:
   group: card-movement-${{ github.event_name != 'issues' && github.event.number || github.event.issue.number }}

--- a/.github/workflows/moving-cards.yml
+++ b/.github/workflows/moving-cards.yml
@@ -5,14 +5,15 @@ on:
     types:
       - created
       - moved
-permissions:
-  contents: read
-  issues: write
-  pull-requests: write
+# Remove all permissions by default
+permissions: {}
 jobs:
   get-issue:
     runs-on: ubuntu-latest
     name: Get issue info
+    permissions:
+      issues: read
+      pull-requests: read
     outputs:
       assignees: ${{ steps.get-issue-step.outputs.assignees }}
       author: ${{ steps.get-issue-step.outputs.author }}
@@ -40,6 +41,10 @@ jobs:
           echo "number=${number}" >> $GITHUB_OUTPUT
   label-card:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     needs:
       - get-issue
     steps:
@@ -108,6 +113,8 @@ jobs:
           remove-labels: in-progress, on-hold
   assign-assignee-if-needed:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs:
       - get-issue
     # The job shouldn't run for solved cards

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,13 +3,15 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 1 * * *'
-permissions:
-  issues: write
-  pull-requests: write
+# Remove all permissions by default
+permissions: {}
 # This job won't trigger any additional event. All actions are performed with GITHUB_TOKEN
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       # This step will add the stale comment and label for the first 15 days without activity. It won't close any task
       - uses: actions/stale@v6.0.1

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,17 +1,18 @@
-name: '[Support] Synchronize labels from the charts repository'
+name: '[Support] Synchronize labels from the containers repository'
 on:
   schedule:
     # Daily
     - cron: '0 3 * * *'
-permissions:
-  issues: write
-
+# Remove all permissions by default
+permissions: {}
 jobs:
   sync-labels:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - uses: EndBug/label-sync@v2
         with:
-          source-repo: bitnami/charts
+          source-repo: bitnami/containers
           delete-other-labels: false
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-teams.yml
+++ b/.github/workflows/sync-teams.yml
@@ -3,9 +3,8 @@ on:
   schedule:
     # Daily
     - cron: '0 5 * * *'
-permissions:
-  # All write actions are executed with BITNAMI_BOT
-  contents: write
+# Remove all permissions by default. Write actions are done by Bitnami Bot
+permissions: {}
 jobs:
   sync-support-teams:
     runs-on: ubuntu-latest

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -9,11 +9,8 @@ on:
     types:
       - reopened
       - opened
-permissions:
-  # Please note that projects cards are created/moved with Bitnami Bot (that's reason to use pull_request_target)
-  contents: read
-  issues: write
-  pull-requests: write
+# Remove all permissions by default
+permissions: {}
 # Avoid concurrency over the same issue
 concurrency:
   group: card-movement-${{ github.event_name != 'issues' && github.event.number || github.event.issue.number }}
@@ -22,6 +19,9 @@ jobs:
   send_to_board:
     name: Organize triage
     runs-on: ubuntu-latest
+    # Please note that projects cards are created/moved with Bitnami Bot
+    permissions:
+      contents: read
     steps:
       - name: Repo checkout
         uses: actions/checkout@v3
@@ -49,15 +49,20 @@ jobs:
           column-name: ${{ (contains(fromJson(env.BITNAMI_TEAM), steps.get-issue.outputs.author)) && 'From Bitnami' || 'Triage' }}
           token: "${{ secrets.BITNAMI_BOT_TOKEN }}"
           issue-number: ${{ steps.get-issue.outputs.number }}
-      # The project API is not efficient and requires several requests to create the project card. For that reason we decided to create
-      # a card for the automated PRs only when it is needed.
+  labeling:
+    name: Set labels for Automated PRs
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    if: ${{ github.event_name != 'issues' && github.event.pull_request.user.login == 'bitnami-bot' }}
+    # The project API is not efficient and requires several requests to create the project card. For that reason we decided to create
+    # a card for the automated PRs only when it is needed.
+    steps:
       - name: From Bitnami labeling
-        if: ${{steps.get-issue.outputs.author == 'bitnami-bot' && steps.get-issue.outputs.type == 'pull_request'}}
         uses: fmulero/labeler@1.1.0
         with:
           add-labels: 'automated, auto-merge'
       - name: Verify labeling
-        if: ${{steps.get-issue.outputs.author == 'bitnami-bot' && steps.get-issue.outputs.type == 'pull_request'}}
         uses: fmulero/labeler@1.1.0
         with:
           # Bitnami bot token is required to trigger CI workflows


### PR DESCRIPTION
### Description of the change

Disable permissions for all scopes by default in GitHub workflows and enable only the permissions required in each job. triage.yaml workflow was refactorized also to split the workload in two different jobs, to restrict a little bit more the scope of the token.

### Benefits

Each job will have only its required permissions according to its needs.

### Possible drawbacks

Not all workflows could be tested in my fork.

### Additional information
* https://github.com/bitnami/charts/pull/17028
* https://github.com/bitnami/containers/pull/36685
* [Assigning permissions to jobs](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs)
* [Automatic token authentication](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)
* [Permissions required for GitHub Apps](https://docs.github.com/en/rest/overview/permissions-required-for-github-apps?apiVersion=2022-11-28)
### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
