### PR TITLE
[bitnami/vms] GitHub Actions Hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Copyright VMware, Inc.
+# SPDX-License-Identifier: APACHE-2.0
+
+version: 2
+# Check for updates to GitHub Actions every week
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/clossing-issues.yml
+++ b/.github/workflows/clossing-issues.yml
@@ -1,5 +1,9 @@
+# Copyright VMware, Inc.
+# SPDX-License-Identifier: APACHE-2.0
+
 name: '[Support] Close Solved issues'
 on:
+  workflow_dispatch:
   schedule:
     # Hourly
     - cron: '0 * * * *'
@@ -9,7 +13,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v6.0.1
+      - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84
         with:
           any-of-labels: 'solved'
           stale-issue-label: 'solved'

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -1,3 +1,6 @@
+# Copyright VMware, Inc.
+# SPDX-License-Identifier: APACHE-2.0
+
 name: '[Support] Comments based card movements'
 on:
   issue_comment:
@@ -18,13 +21,13 @@ jobs:
       pull-requests: read
     steps:
       - name: Repo checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: Load .env file
-        uses: xom9ikk/dotenv@v2
+        uses: xom9ikk/dotenv@de1ff27d319507880e6621e4d47424c677d95f68
         with:
           path: .github/workflows/
       - name: Move into From Build Maintenance
-        uses: peter-evans/create-or-update-project-card@v2
+        uses: peter-evans/create-or-update-project-card@dfa240db6fe287ceb681e45d6728c1af70452c58
         # The comment was created by bitnami-bot in a pull_request created by bitnami-bot
         if: ${{ github.actor == 'bitnami-bot' && github.event.issue.user.login == 'bitnami-bot' && github.event.issue.pull_request != null }}
         with:
@@ -33,7 +36,7 @@ jobs:
           # Required to trigger moving-cards.yml workflow (clean labels and assign people to work on it)
           token: "${{ secrets.BITNAMI_BOT_TOKEN }}"
       - name: Move into Pending
-        uses: peter-evans/create-or-update-project-card@v2
+        uses: peter-evans/create-or-update-project-card@dfa240db6fe287ceb681e45d6728c1af70452c58
         if: |
           (github.actor != 'bitnami-bot' || github.event.issue.user.login != 'bitnami-bot' || github.event.issue.pull_request == null) &&
           contains(fromJson(env.BITNAMI_TEAM), github.actor) &&
@@ -42,7 +45,7 @@ jobs:
           project-name: Support
           column-name: Pending
       - name: Move into In Progress
-        uses: peter-evans/create-or-update-project-card@v2
+        uses: peter-evans/create-or-update-project-card@dfa240db6fe287ceb681e45d6728c1af70452c58
         if: |
           (github.actor != 'bitnami-bot' || github.event.issue.user.login != 'bitnami-bot' || github.event.issue.pull_request == null) &&
           (!contains(fromJson(env.BITNAMI_TEAM), github.actor)) &&
@@ -51,7 +54,7 @@ jobs:
           project-name: Support
           column-name: In progress
       - name: Move into Triage
-        uses: peter-evans/create-or-update-project-card@v2
+        uses: peter-evans/create-or-update-project-card@dfa240db6fe287ceb681e45d6728c1af70452c58
         if: |
           (github.actor != 'bitnami-bot' || github.event.issue.user.login != 'bitnami-bot' || github.event.issue.pull_request == null) &&
           (!contains(fromJson(env.BITNAMI_TEAM), github.actor)) &&

--- a/.github/workflows/delete-solved-cards.yml
+++ b/.github/workflows/delete-solved-cards.yml
@@ -1,3 +1,6 @@
+# Copyright VMware, Inc.
+# SPDX-License-Identifier: APACHE-2.0
+
 name: '[Support] Delete Solved cards'
 on:
   workflow_dispatch:
@@ -14,18 +17,19 @@ jobs:
       contents: read
     steps:
       - name: Repo checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 1
       - name: Load .env file
-        uses: xom9ikk/dotenv@v2
+        uses: xom9ikk/dotenv@de1ff27d319507880e6621e4d47424c677d95f68
         with:
           path: .github/workflows/
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410
         with:
           script: |
+            const {SOLVED_COLUMN_ID} = process.env
             const {data: cards} = await github.rest.projects.listCards({
-              column_id: ${{ env.SOLVED_COLUMN_ID }},
+              column_id: `${SOLVED_COLUMN_ID}`,
               archived_state: 'all',
               per_page: 100
             });

--- a/.github/workflows/markdown-linter.yml
+++ b/.github/workflows/markdown-linter.yml
@@ -1,3 +1,6 @@
+# Copyright VMware, Inc.
+# SPDX-License-Identifier: APACHE-2.0
+
 name: '[CI/CD] Markdown linter'
 on:
   pull_request:
@@ -16,20 +19,21 @@ jobs:
       - name: Install mardownlint
         run: npm install -g markdownlint-cli@0.33.0
       - name: Checkout project
-        uses: actions/checkout@v3
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: Execute markdownlint
         env:
           DIFF_URL: "${{github.event.pull_request.diff_url}}"
           TEMP_FILE: "${{runner.temp}}/pr-${{github.event.number}}.diff"
+          TEMP_OUTPUT: "${{runner.temp}}/output"
         run: |
           # This request doesn't consume API calls.
           curl -Lkso $TEMP_FILE $DIFF_URL
           files_changed="$(sed -nr 's/[\-\+]{3} [ab]\/(.*)/\1/p' $TEMP_FILE | sort | uniq)"
           md_files="$(echo "$files_changed" | grep -o ".*\.md$" | sort | uniq || true)"
           # Create an empty file, useful when the PR changes ignored files
-          touch ${{runner.temp}}/output
+          touch "${TEMP_OUTPUT}"
           exit_code=0
-          markdownlint -o ${{runner.temp}}/output ${md_files[@]} || exit_code=$?
+          markdownlint -o "${TEMP_OUTPUT}" ${md_files[@]} || exit_code=$?
           while read -r line; do
             # line format:
             #   file:row[:column] message
@@ -45,7 +49,7 @@ jobs:
             else
               echo "::warning:: Error processing: ${line}"
             fi
-          done < ${{runner.temp}}/output
+          done < "${TEMP_OUTPUT}"
           if [[ $exit_code -ne 0 ]]; then
             echo "::error:: Please review linter messages"
             exit "$exit_code"

--- a/.github/workflows/move-closed-issues.yml
+++ b/.github/workflows/move-closed-issues.yml
@@ -1,3 +1,6 @@
+# Copyright VMware, Inc.
+# SPDX-License-Identifier: APACHE-2.0
+
 name: '[Support] Move closed issues'
 on:
   issues:
@@ -17,7 +20,7 @@ jobs:
     steps:
       - name: Send to the Solved column
         id: send-solved
-        uses: peter-evans/create-or-update-project-card@v2
+        uses: peter-evans/create-or-update-project-card@dfa240db6fe287ceb681e45d6728c1af70452c58
         # Send to solve only the issues and PRs created by users or the automated PRs with human review required
         if: |
           (github.event.issue != null && github.event.issue.user.login != 'bitnami-bot') ||

--- a/.github/workflows/moving-cards.yml
+++ b/.github/workflows/moving-cards.yml
@@ -1,3 +1,6 @@
+# Copyright VMware, Inc.
+# SPDX-License-Identifier: APACHE-2.0
+
 # This workflow is built to manage the triage support by using GH issues.
 name: '[Support] Cards movements'
 on:
@@ -49,54 +52,48 @@ jobs:
       - get-issue
     steps:
       - name: Repo checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 1
       - name: Load .env file
-        uses: xom9ikk/dotenv@v2
+        uses: xom9ikk/dotenv@de1ff27d319507880e6621e4d47424c677d95f68
         with:
           path: .github/workflows/
       # Now handling the needed labeling
       - name: Triage labeling
         # Only if moved into triage
         if: ${{ github.event.project_card.column_id == env.TRIAGE_COLUMN_ID }}
-        uses: fmulero/labeler@1.1.0
+        uses: fmulero/labeler@f49bf680252fc8ac12cbebb6e0ed8ea19d0712da
         with:
           add-labels: triage
           remove-labels: on-hold, in-progress, solved
       - name: From Bitnami labeling
         if: ${{ github.event.project_card.column_id == env.BITNAMI_COLUMN_ID }}
-        uses: fmulero/labeler@1.1.0
+        uses: fmulero/labeler@f49bf680252fc8ac12cbebb6e0ed8ea19d0712da
         with:
           add-labels: ${{ (needs.get-issue.outputs.author == 'bitnami-bot' && needs.get-issue.outputs.type == 'pull_request') && 'automated, auto-merge' || 'bitnami' }}
           remove-labels: on-hold, in-progress, triage, solved
       - name: Verify labeling
         # Only if moved into bitnami column and the PR is ready for review
-        # Consecutive calls were fixed in fmulero/labeler@1.1.0, see https://github.com/fmulero/labeler/pull/2
+        # Consecutive calls were fixed in fmulero/labeler, see https://github.com/fmulero/labeler/pull/2
         if: |
           github.event.project_card.column_id == env.BITNAMI_COLUMN_ID &&
           needs.get-issue.outputs.type == 'pull_request' && needs.get-issue.outputs.draft == 'false'
-        uses: fmulero/labeler@1.1.0
+        uses: fmulero/labeler@f49bf680252fc8ac12cbebb6e0ed8ea19d0712da
         with:
           repo-token: ${{ secrets.BITNAMI_BOT_TOKEN }}
           add-labels: verify
-      - name: Build Maintenance labeling
-        if: ${{ github.event.project_card.column_id == env.BUILD_MAINTENANCE_COLUMN_ID }}
-        uses: fmulero/labeler@1.1.0
-        with:
-          add-labels: review-required
-          remove-labels: auto-merge
       - name: On hold labeling
         # Only if moved into on hold
         if: ${{ github.event.project_card.column_id == env.ON_HOLD_COLUMN_ID  }}
-        uses: fmulero/labeler@1.1.0
+        uses: fmulero/labeler@f49bf680252fc8ac12cbebb6e0ed8ea19d0712da
         with:
           add-labels: on-hold
           remove-labels: triage, in-progress, solved
       - name: In progress labeling
         # Only if moved into In progress
         if: ${{ github.event.project_card.column_id == env.IN_PROGRESS_COLUMN_ID  }}
-        uses: fmulero/labeler@1.1.0
+        uses: fmulero/labeler@f49bf680252fc8ac12cbebb6e0ed8ea19d0712da
         with:
           add-labels: in-progress
           remove-labels: on-hold, triage, solved
@@ -105,7 +102,7 @@ jobs:
         if: |
           github.event.project_card.column_id == env.SOLVED_COLUMN_ID &&
           (needs.get-issue.outputs.author != 'bitnami-bot')
-        uses: fmulero/labeler@1.1.0
+        uses: fmulero/labeler@f49bf680252fc8ac12cbebb6e0ed8ea19d0712da
         with:
           add-labels: solved
           # Triage is not on the list to know how many issues/PRs are solved
@@ -120,20 +117,18 @@ jobs:
     # The job shouldn't run for solved cards
     steps:
       - name: Repo checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 1
       - name: Load .env file
-        uses: xom9ikk/dotenv@v2
+        uses: xom9ikk/dotenv@de1ff27d319507880e6621e4d47424c677d95f68
         with:
           path: .github/workflows/
       - name: Assign to a person to work on it
         # Assign when there is nobody assigned or the card is new.
-        # Cards in Build Maintenance column will remain unassigned.
         if: |
-          github.event.project_card.column_id != env.SOLVED_COLUMN_ID && github.event.project_card.column_id != env.BUILD_MAINTENANCE_COLUMN_ID &&
-          (needs.get-issue.outputs.assignees == '[]' || github.event.action == 'created')
-        uses: pozil/auto-assign-issue@v1.11.0
+          github.event.project_card.column_id != env.SOLVED_COLUMN_ID && (needs.get-issue.outputs.assignees == '[]' || github.event.action == 'created')
+        uses: pozil/auto-assign-issue@edee9537367a8fbc625d27f9e10aa8bad47b8723
         with:
           numOfAssignee: 1
           teams: ${{ github.event.project_card.column_id == env.BITNAMI_COLUMN_ID && env.SUPPORT_TEAM_NAME || env.TRIAGE_TEAM_NAME }}
@@ -145,7 +140,7 @@ jobs:
           github.event.action == 'moved' && needs.get-issue.outputs.assignees != '[]' &&
           github.event.project_card.column_id == env.IN_PROGRESS_COLUMN_ID &&
           github.event.changes.column_id.from == env.TRIAGE_COLUMN_ID
-        uses: pozil/auto-assign-issue@v1.11.0
+        uses: pozil/auto-assign-issue@edee9537367a8fbc625d27f9e10aa8bad47b8723
         with:
           numOfAssignee: 1
           removePreviousAssignees: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,3 +1,6 @@
+# Copyright VMware, Inc.
+# SPDX-License-Identifier: APACHE-2.0
+
 name: '[Support] Close stale issues and PRs'
 on:
   workflow_dispatch:
@@ -14,7 +17,7 @@ jobs:
       pull-requests: write
     steps:
       # This step will add the stale comment and label for the first 15 days without activity. It won't close any task
-      - uses: actions/stale@v6.0.1
+      - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: 'This Issue has been automatically marked as "stale" because it has not had recent activity (for 15 days). It will be closed if no further activity occurs. Thanks for the feedback.'
@@ -25,7 +28,7 @@ jobs:
           exempt-pr-labels: 'on-hold'
           operations-per-run: 500
       # This step will add the 'solved' label and the last comment before closing the issue or PR. Note that it won't close any issue or PR, they will be closed by the clossing-issues workflow
-      - uses: actions/stale@v6.0.1
+      - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: 'Due to the lack of activity in the last 5 days since it was marked as "stale", we proceed to close this Issue. Do not hesitate to reopen it later if necessary.'

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,3 +1,6 @@
+# Copyright VMware, Inc.
+# SPDX-License-Identifier: APACHE-2.0
+
 name: '[Support] Synchronize labels from the containers repository'
 on:
   workflow_dispatch:
@@ -14,7 +17,7 @@ jobs:
       # Required to read issues from bitnami/containers
       contents: read
     steps:
-      - uses: EndBug/label-sync@v2
+      - uses: EndBug/label-sync@6ba4d3eb919c51aa5b8bf4d574b2161960a9edd3
         with:
           source-repo: bitnami/containers
           delete-other-labels: false

--- a/.github/workflows/sync-teams.yml
+++ b/.github/workflows/sync-teams.yml
@@ -1,5 +1,9 @@
+# Copyright VMware, Inc.
+# SPDX-License-Identifier: APACHE-2.0
+
 name: '[Support] Synchronize team members in the .env file'
 on:
+  workflow_dispatch:
   schedule:
     # Daily
     - cron: '0 5 * * *'
@@ -10,19 +14,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Repo checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           token: ${{ secrets.BITNAMI_BOT_TOKEN }}
           fetch-depth: 1
       - name: Load .env file
-        uses: xom9ikk/dotenv@v2
+        uses: xom9ikk/dotenv@de1ff27d319507880e6621e4d47424c677d95f68
         with:
           path: .github/workflows/
       - name: Updating members of the Bitnami team
+        env:
+          TOKEN: ${{ secrets.BITNAMI_BOT_TOKEN }}
         run: |
           TEAM_MEMBERS=$(curl --request GET \
           --url https://api.github.com/orgs/bitnami/teams/developers/members?per_page=100 \
-          --header 'authorization: Bearer ${{ secrets.BITNAMI_BOT_TOKEN }}' \
+          --header "authorization: Bearer ${TOKEN}" \
           --header 'content-type: application/json' \
           | jq 'sort_by(.login)|map(.login)|join(",")')
           TEAM_MEMBERS='['${TEAM_MEMBERS//','/'","'}']'

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,3 +1,6 @@
+# Copyright VMware, Inc.
+# SPDX-License-Identifier: APACHE-2.0
+
 # This workflow is built to manage the triage support by using GH issues.
 name: '[Support] Organize triage'
 on:
@@ -24,11 +27,11 @@ jobs:
       contents: read
     steps:
       - name: Repo checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 1
       - name: Load .env file
-        uses: xom9ikk/dotenv@v2
+        uses: xom9ikk/dotenv@de1ff27d319507880e6621e4d47424c677d95f68
         with:
           path: .github/workflows/
       - name: Get author
@@ -42,7 +45,7 @@ jobs:
           echo "type=${type}" >> $GITHUB_OUTPUT
       - name: Send to the board
         if: ${{steps.get-issue.outputs.author != 'bitnami-bot' || steps.get-issue.outputs.type != 'pull_request'}}
-        uses: peter-evans/create-or-update-project-card@v2
+        uses: peter-evans/create-or-update-project-card@dfa240db6fe287ceb681e45d6728c1af70452c58
         with:
           project-name: Support
           # If the author comes from Bitnami, send it to Bitnami. Otherwise, all to Triage
@@ -59,11 +62,11 @@ jobs:
     # a card for the automated PRs only when it is needed.
     steps:
       - name: From Bitnami labeling
-        uses: fmulero/labeler@1.1.0
+        uses: fmulero/labeler@f49bf680252fc8ac12cbebb6e0ed8ea19d0712da
         with:
           add-labels: 'automated, auto-merge'
       - name: Verify labeling
-        uses: fmulero/labeler@1.1.0
+        uses: fmulero/labeler@f49bf680252fc8ac12cbebb6e0ed8ea19d0712da
         with:
           # Bitnami bot token is required to trigger CI workflows
           repo-token: ${{ secrets.BITNAMI_BOT_TOKEN }}


### PR DESCRIPTION
### Description of the change

* Use SHA reference for GitHub actions (`vmware-labs/vmware-image-builder-action` is an exception).
* Avoid the use of github context substitution in scripts to prevent script injections.
* Remove third-party actions that can be easily implemented with actions or scripts provided by GitHub.
* Include dependabot rules to update periodically the actions.
* Keep updated the actions.


### Benefits

Apply GitHub best practices, reduce attack surface and risks related to the use of third party actions.

### Possible drawbacks

Some actions has been updated to its latest major version. These actions are:
* apache/skywalking-eyes/header
* pozil/auto-assign-issue
* actions/stale

### Additional information

* [Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)
* https://github.com/bitnami/charts/pull/20675
* https://github.com/bitnami/containers/pull/52441

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
